### PR TITLE
default draft stage on pull request

### DIFF
--- a/backend/src/prManagement.ts
+++ b/backend/src/prManagement.ts
@@ -40,10 +40,11 @@ export async function createPR(branchData: any, commitData: any): Promise<any> {
                 const fullHead = `${commitData.OWNER}:${commitData.branchName}`
         
                 const payload = {
-                    title: 'Adding new resource', 
+                    title: `Adding ${commitData.resourceName}`, 
                     head: fullHead, 
                     base: 'dev', 
-                    body: `This pull rquest adds resource ${commitData.resourceName}`
+                    body: `This pull rquest adds resource ${commitData.resourceName}`,
+                    draft: true,
                 };
                 
                 const prResponse = await axios.post(`https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pulls`, JSON.stringify(payload), {


### PR DESCRIPTION
Minimal changes to resulting pr structure, where now the pr gets created as draft by default, and the pr's title now includes the added resource's name for reference.