### PR TITLE
Minimal changes to UX & fix for empty tags processing

### DIFF
--- a/backend/src/utils/editedResourceParser.ts
+++ b/backend/src/utils/editedResourceParser.ts
@@ -61,7 +61,7 @@ async function parseEvents(data: resourceInterfaces.EventData): Promise<any> {
             language: data.language,
             links: data.links,
             project_id: data.project_id,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         };
 
         const parentPath = await dirManager.createFolder(data.name);
@@ -105,7 +105,7 @@ async function parseNewsletter(data: resourceInterfaces.NewsletterData): Promise
             language: data.language,
             description: correctDescription,
             contributor_names: data.contributor_names,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         }
 
         const parentPath = await dirManager.createFolder(data.title);
@@ -141,7 +141,7 @@ async function parseProfessor(data: resourceInterfaces.ProfessorData): Promise<v
             ...(data.tips && { tips: data.tips }),
             company: data.company ? data.company : undefined ,
             affiliations: data.affiliations,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         }
 
         const parentPath = await dirManager.createFolder(data.name);
@@ -176,7 +176,7 @@ async function parseProjects(data: resourceInterfaces.ProjectData): Promise<void
             ...(data.links && { links: data.links }),
             category: data.category,
             original_language: data.original_language,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
             contributor_names: data.contributor_names,
         }
         const exclude = ['resourceCategory', 'githubUser', 'githubToken'];

--- a/backend/src/utils/resourceParser.ts
+++ b/backend/src/utils/resourceParser.ts
@@ -71,7 +71,7 @@ async function parseEvents(data: resourceInterfaces.EventData, image: any): Prom
                 website: data.website
             },
             project_id: data.project_id,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         };
 
         const parentPath = await dirManager.createFolder(data.name);
@@ -116,7 +116,7 @@ async function parseNewsletter(data: resourceInterfaces.NewsletterData, image: a
             language: data.language,
             description: description,
             contributor_names: data.githubUser,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         }
 
         const parentPath = await dirManager.createFolder(data.title);
@@ -158,7 +158,7 @@ async function parseProfessor(data: resourceInterfaces.ProfessorData, image: any
             ...(data.lightning_address && { tips: { lightning_address: data.lightning_address } }),
             company: data.company ? data.company : undefined ,
             affiliations: data.affiliations,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         }
         const professorENData = {
             bio: data.bio,
@@ -202,7 +202,7 @@ async function parseProjects(data: resourceInterfaces.ProjectData, image: any): 
             ...(links[0 || 1 || 2 || 3] && {links: { website: links[0], twitter: links[1], github: links[2], nostr: links[3] } }),
             category: data.category,
             original_language: data.original_language,
-            tags: data.tags,
+            tags: (data.tags || []).filter(tag => tag && tag.trim() !== ""),
         }
         const projectENData = {
             description: data.description,

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -169,7 +169,7 @@ const EventForm = () => {
         </select>
       </div>
 
-      <div className="flex gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {formData.tags.map((tag, index) => (
           <select key={index} className="p-3 rounded bg-gray-800 text-white" value={tag} onChange={(e) => handleTagChange(index, e.target.value)}>
             <option value="">Select a tag</option>
@@ -177,6 +177,7 @@ const EventForm = () => {
           </select>
         ))}
       </div>
+      <label className="text-xs text-gray-400"> * Select at least two tags.</label>
 
       <button type="submit" className="p-3 bg-orange-600 rounded text-white font-semibold hover:bg-blue-700 transition">Send</button>
     </form>

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -18,7 +18,7 @@ const NewsletterForm = () => {
     website: "",
     language: "",
     description: "",
-    tags: ["", ""],
+    tags: ["", "", ""],
     thumbnail: null as File | null,
     githubUser: "",
     githubToken: "",
@@ -167,6 +167,7 @@ const NewsletterForm = () => {
             </select>
           ))}
         </div>
+        <label className="text-xs text-gray-400"> * Select at least two tags.</label>
       </div>
 
       <div className="flex flex-row items-center gap-4">

--- a/src/components/ProfessorForm.tsx
+++ b/src/components/ProfessorForm.tsx
@@ -36,7 +36,7 @@ const ProfessorForm = () => {
     lightning_address: "",
     company: "",
     affiliations: [""],
-    tags: ["", ""],
+    tags: ["", "", ""],
     bio: "",
     short_bio: "",
     thumbnail: null as File | null,
@@ -204,45 +204,47 @@ const ProfessorForm = () => {
         <input type="text" name="company" placeholder="Company" className="p-3 rounded bg-gray-800 text-white w-full" value={formData.company} onChange={handleChange} />
         </div>
      
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {/* <div className="grid grid-cols-1 md:grid-cols-2 gap-4"> */}
         {/* <div className="flex flex-col gap-2 w-full">
           <label className="text-sm text-gray-400">Affiliations (UUIDs)</label>
           {formData.affiliations.map((aff, index) => (
             <input key={index} type="text" placeholder={`Affiliation ${index + 1}`} className="p-3 rounded bg-gray-800 text-white" value={aff} onChange={(e) => handleArrayChange("affiliations", index, e.target.value)} />
           ))}
         </div> */}
-        <div className="flex gap-2 w-full">
-          {formData.tags.map((tag, index) => (
-            <select
-              key={index}
-              className="p-3 rounded bg-gray-800 text-white"
-              value={tag}
-              onChange={(e) => handleArrayChange("tags", index, e.target.value)}
-            >
-              <option value= "">Select a tag</option>
-              {supportedTags.map((tag) => (
-                <option key={tag} value={tag}>
-                  {tag}
-                </option> 
-              ))}
-            </select>          
-          ))}
-        </div>
+      {/* </div> */}
 
-        <div className="flex flex-row items-center w-full gap-4">
-          <label className="cursor-pointer bg-gray-800 hover:bg-orange-700 text-white text-sm rounded-md transition shadow-md w-full text-center mb-1 py-3">
-            Upload Thumbnail
-            <input type="file" accept="image/*" className="hidden" onChange={(e) => {
-              const file = e.target.files?.[0];
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {formData.tags.map((tag, index) => (
+          <select
+            key={index}
+            className="p-3 rounded bg-gray-800 text-white"
+            value={tag}
+            onChange={(e) => handleArrayChange("tags", index, e.target.value)}
+          >
+            <option value= "">Select a tag</option>
+            {supportedTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option> 
+            ))}
+          </select>          
+        ))}
+      </div>
+      <label className="text-xs text-gray-400"> * Select at least two tags.</label>
+
+      <div className="flex flex-row items-center w-full gap-4">
+        <label className="cursor-pointer bg-gray-800 hover:bg-orange-700 text-white text-sm rounded-md transition shadow-md w-full text-center mb-1 py-3">
+          Upload Profile Picture
+          <input type="file" accept="image/*" className="hidden" onChange={(e) => {
+            const file = e.target.files?.[0];
               if (file) setFormData((prev) => ({ ...prev, thumbnail: file }));
-            }}/>
-          </label>
-          {formData.thumbnail && (
-            <div className="text-green-500 text-xs text-center">
-              Selected image: '{formData.thumbnail.name}'
-            </div>
-          )}
-        </div>
+          }}/>
+        </label>
+        {formData.thumbnail && (
+          <div className="text-green-500 text-xs text-center">
+            Selected image: '{formData.thumbnail.name}'
+          </div>
+        )}
       </div>
 
       <button type="submit" className="p-3 bg-orange-600 rounded text-white font-semibold hover:bg-blue-700 transition w-full">

--- a/src/components/ProjectForm.tsx
+++ b/src/components/ProjectForm.tsx
@@ -160,7 +160,7 @@ const ProjectForm = () => {
 
       <div className="flex flex-row items-center gap-4">
         <label className="cursor-pointer bg-gray-800 hover:bg-orange-700 text-white text-sm px-5 py-3 rounded-md transition shadow-md w-full text-center">
-        Upload Thumbnail
+        Upload Logo
         <input
           type="file"
           accept="image/*"
@@ -259,6 +259,7 @@ const ProjectForm = () => {
           </select>
         ))}
       </div>
+      <label className="text-xs text-gray-400"> * Select at least two tags.</label>
     </div>
 
       <button


### PR DESCRIPTION
Adds the requested changes to UX including:
     - Up to three tags in every resource
     - Label telling the user to select at least two tags

And fixes an issue where if the backend received an empty tag field, it would still parse it and save it on the resulting yml file as ""